### PR TITLE
Update declare_handler! to use '::std::result::Result'.

### DIFF
--- a/wayland-client/src/event_queue.rs
+++ b/wayland-client/src/event_queue.rs
@@ -440,7 +440,7 @@ unsafe extern "C" fn dispatch_func<P: Proxy, H: Handler<P>>(
 macro_rules! declare_handler(
     ($handler_struct: ty, $handler_trait: path, $handled_type: ty) => {
         unsafe impl $crate::Handler<$handled_type> for $handler_struct {
-            unsafe fn message(&mut self, evq: &mut $crate::EventQueueHandle, proxy: &$handled_type, opcode: u32, args: *const $crate::sys::wl_argument) -> Result<(),()> {
+            unsafe fn message(&mut self, evq: &mut $crate::EventQueueHandle, proxy: &$handled_type, opcode: u32, args: *const $crate::sys::wl_argument) -> ::std::result::Result<(),()> {
                 <$handler_struct as $handler_trait>::__message(self, evq, proxy, opcode, args)
             }
         }


### PR DESCRIPTION
I extensively use a custom `Result` type (similar to `std::io::Result`), and `use`ing it causes `declare_handler!` to break. I think some others use custom `Result` types as well. Here's a quick fix.