### PR TITLE
User data safety

### DIFF
--- a/wayland-protocols/src/protocol_macro.rs
+++ b/wayland-protocols/src/protocol_macro.rs
@@ -23,7 +23,7 @@ macro_rules! wayland_protocol(
                     // Imports that need to be available to submodules
                     // but should not be in public API.
                     // Will be fixable with pub(restricted).
-                    #[doc(hidden)] pub use wayland_client::{Proxy, Handler, RequestResult, EventQueueHandle};
+                    #[doc(hidden)] pub use wayland_client::{Proxy, Handler, RequestResult, EventQueueHandle, Liveness};
                     #[doc(hidden)] pub use super::interfaces;
                     #[doc(hidden)] pub use wayland_client::protocol::{$($import),*};
                     include!(concat!(env!("OUT_DIR"), "/", $name, "_client_api.rs"));
@@ -41,7 +41,7 @@ macro_rules! wayland_protocol(
                     // Imports that need to be available to submodules
                     // but should not be in public API.
                     // Will be fixable with pub(restricted).
-                    #[doc(hidden)] pub use wayland_server::{Resource, Handler, EventResult, Client, EventLoopHandle};
+                    #[doc(hidden)] pub use wayland_server::{Resource, Handler, EventResult, Client, EventLoopHandle, Liveness};
                     #[doc(hidden)] pub use super::interfaces;
                     #[doc(hidden)] pub use wayland_server::protocol::{$($import),*};
                     include!(concat!(env!("OUT_DIR"), "/", $name, "_server_api.rs"));

--- a/wayland-scanner/src/code_gen.rs
+++ b/wayland-scanner/src/code_gen.rs
@@ -30,6 +30,7 @@ fn write_interface<O: Write>(interface: &Interface, out: &mut O, side: Side) -> 
     try!(writeln!(out, "use super::{};", side.object_trait()));
     try!(writeln!(out, "use super::{};", side.result_type()));
     try!(writeln!(out, "use super::interfaces::*;"));
+    try!(writeln!(out, "use super::Liveness;"));
     try!(writeln!(out, "use wayland_sys::common::*;"));
     try!(writeln!(out, "use std::ffi::{{CString,CStr}};"));
     try!(writeln!(out, "use std::ptr;"));
@@ -41,11 +42,12 @@ fn write_interface<O: Write>(interface: &Interface, out: &mut O, side: Side) -> 
         Side::Client => try!(writeln!(out, "use wayland_sys::client::*;")),
         Side::Server => try!(writeln!(out, "use wayland_sys::server::*;"))
     };
+    try!(writeln!(out, "use wayland_sys::RUST_MANAGED;"));
 
     try!(writeln!(out,
         r#"pub struct {} {{
             ptr: *mut {},
-            data: Arc<(AtomicBool, AtomicPtr<()>)>
+            data: Option<Arc<(AtomicBool, AtomicPtr<()>)>>
         }}"#,
         snake_to_camel(&interface.name),
         side.object_ptr_type()
@@ -71,16 +73,35 @@ fn write_interface<O: Write>(interface: &Interface, out: &mut O, side: Side) -> 
                 Arc::new((AtomicBool::new(true), AtomicPtr::new(ptr::null_mut())))
             )));
             ffi_dispatch!({2}, {0}_set_user_data, ptr, data as *mut c_void);
-            {1} {{ ptr: ptr, data: (&*data).2.clone() }}
+            {1} {{ ptr: ptr, data: Some((&*data).2.clone()) }}
         }}"#,
         side.object_ptr_type(),
         snake_to_camel(&interface.name),
         side.handle()
     ));
-    try!(writeln!(out,
-        r#"unsafe fn from_ptr_initialized(ptr: *mut {0}) -> {1} {{
-            let data = ffi_dispatch!({2}, {0}_get_user_data, ptr) as *mut (*mut c_void, *mut c_void, Arc<(AtomicBool, AtomicPtr<()>)>);
-            {1} {{ ptr: ptr, data: (&*data).2.clone() }}
+    try!(writeln!(out, "unsafe fn from_ptr_initialized(ptr: *mut {0}) -> {1} {{",
+        side.object_ptr_type(),
+        snake_to_camel(&interface.name)
+    ));
+    if let Side::Client = side {
+        try!(writeln!(out, r#"
+            let implem = ffi_dispatch!(WAYLAND_CLIENT_HANDLE, wl_proxy_get_listener, ptr);
+            let rust_managed = implem == &RUST_MANAGED as *const _ as *const _;
+        "#));
+    } else {
+        try!(writeln!(out, r#"
+            let rust_managed = ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_resource_instance_of,
+                ptr, Self::interface_ptr(), &RUST_MANAGED as *const _ as *const _
+            ) != 0;
+        "#));
+    }
+    try!(writeln!(out, r#"
+            if rust_managed {{
+                let data = ffi_dispatch!({2}, {0}_get_user_data, ptr) as *mut (*mut c_void, *mut c_void, Arc<(AtomicBool, AtomicPtr<()>)>);
+                {1} {{ ptr: ptr, data: Some((&*data).2.clone()) }}
+            }} else {{
+                {1} {{ ptr: ptr, data: Option::None }}
+            }}
         }}"#,
         side.object_ptr_type(),
         snake_to_camel(&interface.name),
@@ -97,18 +118,41 @@ fn write_interface<O: Write>(interface: &Interface, out: &mut O, side: Side) -> 
         Side::Client => try!(writeln!(out, "fn version(&self) -> u32 {{ unsafe {{ ffi_dispatch!(WAYLAND_CLIENT_HANDLE, wl_proxy_get_version, self.ptr()) }} }}")),
         Side::Server => try!(writeln!(out, "fn version(&self) -> i32 {{ unsafe {{ ffi_dispatch!(WAYLAND_SERVER_HANDLE, wl_resource_get_version, self.ptr()) }} }}"))
     };
-    try!(writeln!(out, "fn is_alive(&self) -> bool {{ self.data.0.load(Ordering::SeqCst) }}"));
+    try!(writeln!(out, r#"
+        fn status(&self) -> Liveness {{
+            if let Some(ref data) = self.data {{
+                if data.0.load(Ordering::SeqCst) {{
+                    Liveness::Alive
+                }} else {{
+                    Liveness::Dead
+                }}
+            }} else {{
+                Liveness::Unmanaged
+            }}
+        }}"#
+    ));
 
     try!(writeln!(out,
-        "fn equals(&self, other: &{}) -> bool {{ self.is_alive() && other.is_alive() && self.ptr == other.ptr }}",
+        r#"fn equals(&self, other: &{}) -> bool {{
+            self.status() != Liveness::Dead && other.status() != Liveness::Dead && self.ptr == other.ptr
+        }}"#,
         snake_to_camel(&interface.name)
     ));
 
     try!(writeln!(out,
         r#"
-        fn set_user_data(&self, ptr: *mut ()) {{ self.data.1.store(ptr, Ordering::SeqCst) }}
-        fn get_user_data(&self) -> *mut () {{ self.data.1.load(Ordering::SeqCst) }}
-        "#
+        fn set_user_data(&self, ptr: *mut ()) {{
+            if let Some(ref data) = self.data {{
+                data.1.store(ptr, Ordering::SeqCst);
+            }}
+        }}
+        fn get_user_data(&self) -> *mut () {{
+            if let Some(ref data) = self.data {{
+                data.1.load(Ordering::SeqCst)
+            }} else {{
+                ::std::ptr::null_mut()
+            }}
+        }}"#
     ));
 
     try!(writeln!(out, "}}"));
@@ -484,7 +528,7 @@ fn write_impl<O: Write>(messages: &[Message], out: &mut O, iname: &str, side: Si
 
         // check liveness
         if destroyable {
-            try!(writeln!(out, "if !self.is_alive() {{ return {}::Destroyed }}", side.result_type()));
+            try!(writeln!(out, "if self.status() == Liveness::Dead {{ return {}::Destroyed }}", side.result_type()));
         }
 
         // arg translation for some types

--- a/wayland-sys/src/lib.rs
+++ b/wayland-sys/src/lib.rs
@@ -42,6 +42,15 @@ extern crate lazy_static;
 #[cfg(feature = "server")]
 extern crate libc;
 
+/// Magic pointer for wayland objects managed by wayland-client or wayland-server
+///
+/// This static serves no purpose other than existing, and thus providing a stable pointer
+/// to something we know what it is.
+///
+/// It is used internally by wayland-client, wayland-server and wayland-scanner to ensure safety
+/// regarding to wayland objects that are created by some other library.
+pub static RUST_MANAGED: u8 = 42;
+
 pub mod common;
 
 #[cfg(feature = "client")]


### PR DESCRIPTION
This implements a safety mechanism regarding foreign wayland objects and `user_data`:

When wrapping a wayland object, we try to recognize a magic pointer we stored in its implementation (that we don't use because we have a custom dispatcher). If this pointer is not there, this means this object is not ours, and we act conservatively and don't try to read its user_data or manage it in any way.