### PR TITLE
Add fmt::Debug trait for RequestResult

### DIFF
--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -231,6 +231,7 @@ pub trait Proxy {
 }
 
 /// Possible outcome of the call of a request on a proxy
+#[derive(Debug)]
 pub enum RequestResult<T> {
     /// Message has been buffered and will be sent to server
     Sent(T),


### PR DESCRIPTION
Speaks for itself; I wanted to use `debug!("stuff : {:?}")` on a `RequestResult` to have it nicely in my logs. Turns out a fmt::Debug impl was missing.