### PR TITLE
Rework resource_is_registered function

### DIFF
--- a/wayland-server/src/event_loop.rs
+++ b/wayland-server/src/event_loop.rs
@@ -177,12 +177,13 @@ impl EventLoopHandle {
                 resource.ptr()
             ) as *mut _;
             (&mut *data).0 = self as *const _  as *mut _;
+            (&mut *data).1 = h as *const _ as *mut c_void;
             ffi_dispatch!(
                 WAYLAND_SERVER_HANDLE,
                 wl_resource_set_dispatcher,
                 resource.ptr(),
                 dispatch_func::<R,H>,
-                h as *const _ as *const c_void,
+                &RUST_MANAGED as *const _ as *const _,
                 data as *mut c_void,
                 Some(resource_destroy::<R, D>)
             );
@@ -258,7 +259,7 @@ pub fn resource_is_registered<R, H>(resource: &R, handler_id: usize) -> bool
             wl_resource_instance_of,
             resource.ptr(),
             R::interface_ptr(),
-            h as *const _ as *const c_void
+            &RUST_MANAGED as *const _ as *const _
         )
     };
     ret == 1


### PR DESCRIPTION
I find the resource_is_registered function do not work as it expected.
* If the resource is registered by EventLoop.register api, the result of calling resource_is_register will be false.
* If the resource is registered by EventLoop.register_with_destructor, the result of calling resource_is_register will be true.

So I make this pull request to fix it. Here are a few things I have done.
* Fix the  resource_is_registered 
```
        ffi_dispatch!(
            WAYLAND_SERVER_HANDLE,
            wl_resource_instance_of,
            resource.ptr(),
            R::interface_ptr(),
            h as *const _ as *const c_void
        )

```
   to 
```
        ffi_dispatch!(
            WAYLAND_SERVER_HANDLE,
            wl_resource_instance_of,
            resource.ptr(),
            R::interface_ptr(),
            &RUST_MANAGED as *const _ as *const _
        )

```
* Re-implement register by calling register_with_destructor because of their extremely similar logic.