### PR TITLE
Test infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ os:
 
 script:
   - cargo fmt --all -- --write-mode=diff
-  - travis-cargo test
+  - cargo test
 
 after_success:
   - mdbook build
@@ -44,8 +44,6 @@ after_success:
 
 env:
   global:
-    # override the default `--features unstable` used for the nightly branch (optional)
-    - TRAVIS_CARGO_NIGHTLY_FEATURE=""
     - secure: A/zuPuIu03Z+rqnDS/NNNjbXrg8Nc9lEGKzcBdpHgnyd23z37zreEEAKzFhjJKMx0np0ntDo5LVeLgT6d7fGaDFsJrBZHej3pxuG81MAJdLEmJNaCLCc1eCbwDHgJkEJ5HsblHTrYK0RjBvNL5I8+URuzEqXkwVr7UHJv5px1ZA=
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,15 @@
 language: rust
 
-sudo: false
+sudo: required
 
 cache: cargo
+
+dist: trusty
+
+before_install:
+  - sudo add-apt-repository -y ppa:wayland.admin/daily-builds
+  - sudo apt-get update -qq
+  - sudo apt-get install -y libwayland-dev
 
 rust:
   - stable
@@ -28,26 +35,7 @@ os:
 
 script:
   - cargo fmt --all -- --write-mode=diff
-  - |
-      cd wayland-sys &&
-      travis-cargo test -- --features "dlopen egl client server cursor" &&
-      travis-cargo --only nightly doc -- --no-deps --features "dlopen egl client server cursor" &&
-      cd ../wayland-scanner &&
-      travis-cargo test &&
-      travis-cargo --only nightly doc -- --no-deps &&
-      cd ../wayland-client &&
-      travis-cargo test -- --features "dlopen egl cursor" &&
-      travis-cargo --only nightly doc -- --no-deps --features "dlopen egl cursor" &&
-      cd ../wayland-server &&
-      travis-cargo test -- --features "dlopen" &&
-      travis-cargo --only nightly doc -- --no-deps --features "dlopen" &&
-      cd ../wayland-protocols &&
-      travis-cargo test -- --features "unstable_protocols client server wayland-client/dlopen wayland-server/dlopen" &&
-      travis-cargo --only nigthly test -- features "unstable_protocols client server nightly wayland-client/dlopen wayland-server/dlopen" &&
-      travis-cargo --only nightly doc -- --no-deps --features "unstable_protocols client server nightly wayland-client/dlopen wayland-server/dlopen" &&
-      cd .. &&
-      travis-cargo test
-      echo "Finished !"
+  - travis-cargo test
 
 after_success:
   - mdbook build

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ os:
 script:
   - cargo fmt --all -- --write-mode=diff
   - cargo test
+  - travis-cargo --only nightly doc -- --all --no-deps --all-features
 
 after_success:
   - mdbook build

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ script:
       travis-cargo --only nigthly test -- features "unstable_protocols client server nightly wayland-client/dlopen wayland-server/dlopen" &&
       travis-cargo --only nightly doc -- --no-deps --features "unstable_protocols client server nightly wayland-client/dlopen wayland-server/dlopen" &&
       cd .. &&
+      travis-cargo test
       echo "Finished !"
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ os:
 script:
   - cargo fmt --all -- --write-mode=diff
   - cargo test
-  - travis-cargo --only nightly doc -- --all --no-deps --all-features
+  - travis-cargo -q --only nightly doc -- --all --no-deps --all-features
 
 after_success:
   - mdbook build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,11 @@
+[package]
+name = "wayland-test"
+version = "0.0.1"
+publish = false
+
+[dependencies]
+wayland-client = { path = "./wayland-client" }
+wayland-server = { path = "./wayland-server" }
+
 [workspace]
 members = [ "wayland-sys", "wayland-scanner", "wayland-client", "wayland-server", "wayland-protocols" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 publish = false
 
 [dependencies]
-wayland-client = { path = "./wayland-client", features = ["egl", "cursor"] }
+wayland-client = { path = "./wayland-client", default-features = false, features = ["cursor"] }
 wayland-server = { path = "./wayland-server" }
 wayland-protocols = { path = "./wayland-protocols", features = ["client", "server", "unstable_protocols"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,9 @@ version = "0.0.1"
 publish = false
 
 [dependencies]
-wayland-client = { path = "./wayland-client" }
+wayland-client = { path = "./wayland-client", features = ["egl", "cursor"] }
 wayland-server = { path = "./wayland-server" }
+wayland-protocols = { path = "./wayland-protocols", features = ["client", "server", "unstable_protocols"] }
 
 [workspace]
 members = [ "wayland-sys", "wayland-scanner", "wayland-client", "wayland-server", "wayland-protocols" ]

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -1,0 +1,2 @@
+// This module contains helpers functions and types that
+// are not test in themselves, but are used by several tests.

--- a/tests/skel.rs
+++ b/tests/skel.rs
@@ -1,0 +1,9 @@
+extern crate wayland_client;
+extern crate wayland_server;
+
+mod helpers;
+
+#[test]
+fn skel() {
+    assert!(true);
+}

--- a/wayland-protocols/Cargo.toml
+++ b/wayland-protocols/Cargo.toml
@@ -15,7 +15,7 @@ travis-ci = { repository = "vberger/wayland-rs" }
 
 [dependencies]
 wayland-sys = { version = "0.9.3", path = "../wayland-sys" }
-wayland-client = { version = "0.9.3", path = "../wayland-client", optional = true }
+wayland-client = { version = "0.9.3", path = "../wayland-client", optional = true, default-features = false }
 wayland-server = { version = "0.9.3", path = "../wayland-server", optional = true }
 bitflags = "0.7"
 


### PR DESCRIPTION
Basic test infrastructure for the set of libs.

Client & Server libs need to be tested together, so we cannot really unit-test them. Luckily cargo supports packages composed entirely of tests, so the root of the workspace will host them. 😄 

I'll add some tests before merging.